### PR TITLE
feat(design): modernize to dark-first design with emerald accents

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -58,23 +58,23 @@ function BlogLoading() {
     <div className='space-y-8'>
       {Array.from({ length: 5 }).map((_, i) => (
         <div key={i} className='animate-pulse'>
-          <div className='bg-card border border-emerald-100 rounded-lg p-6 shadow-sm'>
+          <div className='bg-card border border-emerald-100 dark:border-emerald-900/20 rounded-lg p-6 shadow-sm'>
             <div className='flex gap-2 mb-4'>
-              <div className='h-6 w-16 bg-emerald-100 rounded'></div>
-              <div className='h-6 w-20 bg-emerald-100 rounded'></div>
-              <div className='h-6 w-24 bg-emerald-100 rounded'></div>
+              <div className='h-6 w-16 bg-emerald-100 dark:bg-emerald-900/30 rounded'></div>
+              <div className='h-6 w-20 bg-emerald-100 dark:bg-emerald-900/30 rounded'></div>
+              <div className='h-6 w-24 bg-emerald-100 dark:bg-emerald-900/30 rounded'></div>
             </div>
-            <div className='h-8 bg-emerald-100 rounded mb-4'></div>
+            <div className='h-8 bg-emerald-100 dark:bg-emerald-900/30 rounded mb-4'></div>
             <div className='flex gap-4 mb-4'>
-              <div className='h-4 w-32 bg-emerald-100 rounded'></div>
-              <div className='h-4 w-20 bg-emerald-100 rounded'></div>
+              <div className='h-4 w-32 bg-emerald-100 dark:bg-emerald-900/30 rounded'></div>
+              <div className='h-4 w-20 bg-emerald-100 dark:bg-emerald-900/30 rounded'></div>
             </div>
             <div className='space-y-2 mb-4'>
-              <div className='h-4 bg-emerald-100 rounded'></div>
-              <div className='h-4 bg-emerald-100 rounded'></div>
-              <div className='h-4 bg-emerald-100 rounded w-3/4'></div>
+              <div className='h-4 bg-emerald-100 dark:bg-emerald-900/30 rounded'></div>
+              <div className='h-4 bg-emerald-100 dark:bg-emerald-900/30 rounded'></div>
+              <div className='h-4 bg-emerald-100 dark:bg-emerald-900/30 rounded w-3/4'></div>
             </div>
-            <div className='h-4 w-24 bg-emerald-100 rounded'></div>
+            <div className='h-4 w-24 bg-emerald-100 dark:bg-emerald-900/30 rounded'></div>
           </div>
         </div>
       ))}
@@ -88,15 +88,15 @@ async function BlogContent() {
   return (
     <>
       {/* Blog posts count and summary */}
-      <div className='mb-8 p-4 bg-emerald-50 rounded-lg border border-emerald-100'>
+      <div className='mb-8 p-4 bg-emerald-50 dark:bg-card rounded-lg border border-emerald-100 dark:border-emerald-900/20'>
         <div className='flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2'>
-          <p className='text-sage-700'>
-            <span className='font-semibold text-emerald-700'>
+          <p className='text-sage-700 dark:text-slate-300'>
+            <span className='font-semibold text-emerald-700 dark:text-emerald-400'>
               {posts.length}
             </span>{' '}
             articles available
           </p>
-          <p className='text-sm text-sage-600'>
+          <p className='text-sm text-sage-600 dark:text-slate-400'>
             Latest:{' '}
             {posts.length > 0
               ? new Date(posts[0].date).toLocaleDateString('en-US', {
@@ -120,9 +120,9 @@ async function BlogContent() {
       {posts.length === 0 && (
         <div className='text-center py-16'>
           <div className='max-w-md mx-auto'>
-            <div className='w-24 h-24 mx-auto mb-6 bg-emerald-100 rounded-full flex items-center justify-center'>
+            <div className='w-24 h-24 mx-auto mb-6 bg-emerald-100 dark:bg-emerald-900/30 rounded-full flex items-center justify-center'>
               <svg
-                className='w-12 h-12 text-emerald-600'
+                className='w-12 h-12 text-emerald-600 dark:text-emerald-400'
                 fill='none'
                 stroke='currentColor'
                 viewBox='0 0 24 24'
@@ -136,16 +136,16 @@ async function BlogContent() {
                 />
               </svg>
             </div>
-            <h3 className='text-xl font-semibold mb-3 text-sage-900'>
+            <h3 className='text-xl font-semibold mb-3 text-sage-900 dark:text-slate-100'>
               No posts found
             </h3>
-            <p className='text-sage-700 mb-6'>
+            <p className='text-sage-700 dark:text-slate-300 mb-6'>
               There are no blog posts available at the moment. Check back soon
               for new content!
             </p>
             <Link
               href='/'
-              className='inline-flex items-center px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 transition-colors'
+              className='inline-flex items-center px-4 py-2 bg-emerald-600 dark:bg-emerald-500 text-white rounded-lg hover:bg-emerald-700 dark:hover:bg-emerald-400 transition-colors'
             >
               Return to Home
             </Link>
@@ -168,7 +168,7 @@ export default async function BlogPage() {
             <div className='mb-8'>
               <Link
                 href='/'
-                className='inline-flex items-center gap-2 text-sage-600 hover:text-emerald-600 transition-colors mb-6 group'
+                className='inline-flex items-center gap-2 text-sage-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors mb-6 group'
               >
                 <ArrowLeft className='h-4 w-4 transition-transform group-hover:-translate-x-1' />
                 Back to Home
@@ -176,17 +176,19 @@ export default async function BlogPage() {
 
               <div className='flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4'>
                 <div>
-                  <h1 className='text-4xl font-bold text-sage-900 mb-2'>
+                  <h1 className='text-4xl font-bold text-sage-900 dark:text-slate-100 mb-2'>
                     Blog
                   </h1>
-                  <p className='text-lg text-sage-700'>
+                  <p className='text-lg text-sage-700 dark:text-slate-300'>
                     Insights, articles, and updates on software development,
                     technology, and leadership.
                   </p>
                 </div>
                 <div className='flex flex-col sm:items-end gap-2'>
                   <RSSLink />
-                  <p className='text-sm text-sage-600'>Subscribe for updates</p>
+                  <p className='text-sm text-sage-600 dark:text-slate-400'>
+                    Subscribe for updates
+                  </p>
                 </div>
               </div>
             </div>
@@ -203,35 +205,47 @@ export default async function BlogPage() {
             </div>
 
             {/* Footer section */}
-            <div className='text-center mt-16 pt-8 border-t border-emerald-100'>
+            <div className='text-center mt-16 pt-8 border-t border-emerald-100 dark:border-emerald-900/20'>
               <div className='max-w-2xl mx-auto'>
-                <h3 className='text-lg font-semibold mb-4 text-sage-900'>
+                <h3 className='text-lg font-semibold mb-4 text-sage-900 dark:text-slate-100'>
                   Stay Connected
                 </h3>
-                <p className='text-sage-700 mb-6'>
+                <p className='text-sage-700 dark:text-slate-300 mb-6'>
                   More articles coming soon! Follow me on{' '}
                   <Link
                     href='https://linkedin.com/in/geovannycordero'
                     target='_blank'
                     rel='noopener noreferrer'
-                    className='text-emerald-600 hover:text-emerald-700 underline font-medium'
+                    className='text-emerald-600 dark:text-emerald-400 hover:text-emerald-700 dark:hover:text-emerald-300 underline font-medium'
                   >
                     LinkedIn
                   </Link>{' '}
                   for updates and insights.
                 </p>
                 <div className='grid sm:grid-cols-3 gap-4 text-sm'>
-                  <div className='flex items-center justify-center gap-2 p-3 bg-emerald-50 rounded-lg'>
-                    <span className='text-emerald-600'>📧</span>
-                    <span className='text-sage-700'>RSS Feed Available</span>
+                  <div className='flex items-center justify-center gap-2 p-3 bg-emerald-50 dark:bg-card rounded-lg'>
+                    <span className='text-emerald-600 dark:text-emerald-400'>
+                      📧
+                    </span>
+                    <span className='text-sage-700 dark:text-slate-300'>
+                      RSS Feed Available
+                    </span>
                   </div>
-                  <div className='flex items-center justify-center gap-2 p-3 bg-emerald-50 rounded-lg'>
-                    <span className='text-emerald-600'>🔄</span>
-                    <span className='text-sage-700'>Updated Regularly</span>
+                  <div className='flex items-center justify-center gap-2 p-3 bg-emerald-50 dark:bg-card rounded-lg'>
+                    <span className='text-emerald-600 dark:text-emerald-400'>
+                      🔄
+                    </span>
+                    <span className='text-sage-700 dark:text-slate-300'>
+                      Updated Regularly
+                    </span>
                   </div>
-                  <div className='flex items-center justify-center gap-2 p-3 bg-emerald-50 rounded-lg'>
-                    <span className='text-emerald-600'>💡</span>
-                    <span className='text-sage-700'>Tech Insights</span>
+                  <div className='flex items-center justify-center gap-2 p-3 bg-emerald-50 dark:bg-card rounded-lg'>
+                    <span className='text-emerald-600 dark:text-emerald-400'>
+                      💡
+                    </span>
+                    <span className='text-sage-700 dark:text-slate-300'>
+                      Tech Insights
+                    </span>
                   </div>
                 </div>
               </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -280,14 +280,8 @@
   background: linear-gradient(to right, #34d399, #22d3ee);
   -webkit-background-clip: text;
   background-clip: text;
+  -webkit-text-fill-color: transparent;
   color: transparent;
-}
-
-.glass {
-  background: rgba(17, 24, 39, 0.8);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  border: 1px solid rgba(16, 185, 129, 0.12);
 }
 
 .glow-emerald {

--- a/app/globals.css
+++ b/app/globals.css
@@ -23,7 +23,31 @@
     --input: 214.3 31.8% 91.4%;
     --ring: 142 76% 36%;
     --radius: 0.75rem;
+  }
 
+  .dark {
+    --background: 150 20% 4%;
+    --foreground: 210 40% 96%;
+    --card: 222 47% 11%;
+    --card-foreground: 210 40% 96%;
+    --popover: 222 47% 11%;
+    --popover-foreground: 210 40% 96%;
+    --primary: 158 64% 52%;
+    --primary-foreground: 150 20% 4%;
+    --secondary: 158 30% 15%;
+    --secondary-foreground: 158 64% 52%;
+    --muted: 222 30% 14%;
+    --muted-foreground: 215 14% 47%;
+    --accent: 158 30% 15%;
+    --accent-foreground: 158 64% 52%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 158 25% 18%;
+    --input: 158 25% 18%;
+    --ring: 158 64% 52%;
+  }
+
+  :root {
     /* Modern Green color palette */
     --emerald-50: 151 81% 96%;
     --emerald-100: 149 80% 90%;
@@ -251,21 +275,44 @@
   }
 }
 
+/* ========== Dark mode design utilities ========== */
+.gradient-text {
+  background: linear-gradient(to right, #34d399, #22d3ee);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.glass {
+  background: rgba(17, 24, 39, 0.8);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(16, 185, 129, 0.12);
+}
+
+.glow-emerald {
+  transition: box-shadow 0.3s ease;
+}
+
+.glow-emerald:hover {
+  box-shadow: 0 0 24px rgba(16, 185, 129, 0.25);
+}
+
 /* Custom styles for blog content */
 .prose {
   @apply text-foreground;
 }
 
 .prose h2 {
-  @apply text-2xl font-bold mt-8 mb-4 text-emerald-800;
+  @apply text-2xl font-bold mt-8 mb-4 text-emerald-800 dark:text-emerald-400;
 }
 
 .prose h3 {
-  @apply text-xl font-semibold mt-6 mb-3 text-emerald-700;
+  @apply text-xl font-semibold mt-6 mb-3 text-emerald-700 dark:text-emerald-400;
 }
 
 .prose p {
-  @apply mb-4 leading-relaxed text-sage-700;
+  @apply mb-4 leading-relaxed text-sage-700 dark:text-slate-300;
 }
 
 .prose ul {
@@ -273,19 +320,19 @@
 }
 
 .prose li {
-  @apply text-sage-700;
+  @apply text-sage-700 dark:text-slate-300;
 }
 
 .prose strong {
-  @apply text-emerald-800 font-semibold;
+  @apply text-emerald-800 dark:text-emerald-400 font-semibold;
 }
 
 .prose code {
-  @apply bg-emerald-50 text-emerald-800 px-1 py-0.5 rounded text-sm;
+  @apply bg-emerald-50 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-400 px-1 py-0.5 rounded text-sm;
 }
 
 .prose blockquote {
-  @apply border-l-4 border-emerald-300 pl-4 italic text-sage-600;
+  @apply border-l-4 border-emerald-300 dark:border-emerald-700 pl-4 italic text-sage-600 dark:text-slate-400;
 }
 
 /* Smooth scrolling for anchor links */
@@ -351,21 +398,21 @@ a {
   @apply transition-colors duration-200;
 }
 
-/* Custom scrollbar for webkit browsers with green theme */
+/* Custom scrollbar for webkit browsers */
 ::-webkit-scrollbar {
   width: 8px;
 }
 
 ::-webkit-scrollbar-track {
-  @apply bg-emerald-50;
+  @apply bg-emerald-50 dark:bg-gray-900;
 }
 
 ::-webkit-scrollbar-thumb {
-  @apply bg-emerald-200 rounded-full;
+  @apply bg-emerald-200 dark:bg-emerald-900 rounded-full;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  @apply bg-emerald-300;
+  @apply bg-emerald-300 dark:bg-emerald-700;
 }
 
 /* Ensure smooth scrolling works on all browsers */
@@ -417,6 +464,15 @@ a {
 
 .card-elegant:hover {
   @apply border-emerald-200 shadow-emerald-100/20;
+}
+
+.dark .card-elegant {
+  border-color: rgba(16, 185, 129, 0.12);
+}
+
+.dark .card-elegant:hover {
+  border-color: rgba(16, 185, 129, 0.3);
+  box-shadow: 0 0 20px rgba(16, 185, 129, 0.08);
 }
 
 /* Text selection */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -93,7 +93,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang='en' className='scroll-smooth'>
+    <html lang='en' className='scroll-smooth dark'>
       <head>
         {/* Favicon and Icons */}
         <link rel='icon' href='/favicon.ico' sizes='any' />

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -38,27 +38,27 @@ function ProjectsLoading() {
     <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8'>
       {Array.from({ length: 6 }).map((_, i) => (
         <div key={i} className='animate-pulse'>
-          <div className='bg-card border border-emerald-100 rounded-lg shadow-sm'>
-            <div className='h-48 bg-emerald-100 rounded-t-lg'></div>
+          <div className='bg-card border border-emerald-100 dark:border-emerald-900/20 rounded-lg shadow-sm'>
+            <div className='h-48 bg-emerald-100 dark:bg-emerald-900/30 rounded-t-lg'></div>
             <div className='p-6 space-y-4'>
               <div className='flex justify-between items-start'>
-                <div className='h-6 w-3/4 bg-emerald-100 rounded'></div>
-                <div className='h-4 w-16 bg-emerald-100 rounded'></div>
+                <div className='h-6 w-3/4 bg-emerald-100 dark:bg-emerald-900/30 rounded'></div>
+                <div className='h-4 w-16 bg-emerald-100 dark:bg-emerald-900/30 rounded'></div>
               </div>
-              <div className='h-4 w-20 bg-emerald-100 rounded'></div>
+              <div className='h-4 w-20 bg-emerald-100 dark:bg-emerald-900/30 rounded'></div>
               <div className='space-y-2'>
-                <div className='h-4 bg-emerald-100 rounded'></div>
-                <div className='h-4 bg-emerald-100 rounded'></div>
-                <div className='h-4 bg-emerald-100 rounded w-2/3'></div>
+                <div className='h-4 bg-emerald-100 dark:bg-emerald-900/30 rounded'></div>
+                <div className='h-4 bg-emerald-100 dark:bg-emerald-900/30 rounded'></div>
+                <div className='h-4 bg-emerald-100 dark:bg-emerald-900/30 rounded w-2/3'></div>
               </div>
               <div className='flex gap-2'>
-                <div className='h-6 w-16 bg-emerald-100 rounded'></div>
-                <div className='h-6 w-20 bg-emerald-100 rounded'></div>
-                <div className='h-6 w-14 bg-emerald-100 rounded'></div>
+                <div className='h-6 w-16 bg-emerald-100 dark:bg-emerald-900/30 rounded'></div>
+                <div className='h-6 w-20 bg-emerald-100 dark:bg-emerald-900/30 rounded'></div>
+                <div className='h-6 w-14 bg-emerald-100 dark:bg-emerald-900/30 rounded'></div>
               </div>
               <div className='flex gap-4'>
-                <div className='h-4 w-16 bg-emerald-100 rounded'></div>
-                <div className='h-4 w-20 bg-emerald-100 rounded'></div>
+                <div className='h-4 w-16 bg-emerald-100 dark:bg-emerald-900/30 rounded'></div>
+                <div className='h-4 w-20 bg-emerald-100 dark:bg-emerald-900/30 rounded'></div>
               </div>
             </div>
           </div>
@@ -74,15 +74,15 @@ async function ProjectsContent() {
   return (
     <>
       {/* Projects count and summary */}
-      <div className='mb-8 p-4 bg-emerald-50 rounded-lg border border-emerald-100'>
+      <div className='mb-8 p-4 bg-emerald-50 dark:bg-card rounded-lg border border-emerald-100 dark:border-emerald-900/20'>
         <div className='flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2'>
-          <p className='text-sage-700'>
-            <span className='font-semibold text-emerald-700'>
+          <p className='text-sage-700 dark:text-slate-300'>
+            <span className='font-semibold text-emerald-700 dark:text-emerald-400'>
               {projects.length}
             </span>{' '}
             projects showcased
           </p>
-          <div className='flex items-center gap-4 text-sm text-sage-600'>
+          <div className='flex items-center gap-4 text-sm text-sage-600 dark:text-slate-400'>
             <div className='flex items-center gap-1'>
               <Briefcase className='h-4 w-4' />
               <span>
@@ -118,19 +118,19 @@ async function ProjectsContent() {
       {projects.length === 0 && (
         <div className='text-center py-16'>
           <div className='max-w-md mx-auto'>
-            <div className='w-24 h-24 mx-auto mb-6 bg-emerald-100 rounded-full flex items-center justify-center'>
-              <Code className='w-12 h-12 text-emerald-600' />
+            <div className='w-24 h-24 mx-auto mb-6 bg-emerald-100 dark:bg-emerald-900/30 rounded-full flex items-center justify-center'>
+              <Code className='w-12 h-12 text-emerald-600 dark:text-emerald-400' />
             </div>
-            <h3 className='text-xl font-semibold mb-3 text-sage-900'>
+            <h3 className='text-xl font-semibold mb-3 text-sage-900 dark:text-slate-100'>
               No projects found
             </h3>
-            <p className='text-sage-700 mb-6'>
+            <p className='text-sage-700 dark:text-slate-300 mb-6'>
               There are no projects available at the moment. Check back soon for
               new additions!
             </p>
             <Link
               href='/'
-              className='inline-flex items-center px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 transition-colors'
+              className='inline-flex items-center px-4 py-2 bg-emerald-600 dark:bg-emerald-500 text-white rounded-lg hover:bg-emerald-700 dark:hover:bg-emerald-400 transition-colors'
             >
               Return to Home
             </Link>
@@ -153,17 +153,17 @@ export default async function ProjectsPage() {
             <div className='mb-8'>
               <Link
                 href='/'
-                className='inline-flex items-center gap-2 text-sage-600 hover:text-emerald-600 transition-colors mb-6 group'
+                className='inline-flex items-center gap-2 text-sage-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors mb-6 group'
               >
                 <ArrowLeft className='h-4 w-4 transition-transform group-hover:-translate-x-1' />
                 Back to Home
               </Link>
 
               <div className='text-left mb-8'>
-                <h1 className='text-4xl font-bold text-sage-900 mb-4'>
+                <h1 className='text-4xl font-bold text-sage-900 dark:text-slate-100 mb-4'>
                   My Projects
                 </h1>
-                <p className='text-lg text-sage-700'>
+                <p className='text-lg text-sage-700 dark:text-slate-300'>
                   A collection of software development projects showcasing my
                   expertise in full-stack development, API design, and modern
                   web technologies.
@@ -179,19 +179,19 @@ export default async function ProjectsPage() {
             </div>
 
             {/* Footer section */}
-            <div className='text-center mt-16 pt-8 border-t border-emerald-100'>
+            <div className='text-center mt-16 pt-8 border-t border-emerald-100 dark:border-emerald-900/20'>
               <div className='max-w-2xl mx-auto'>
-                <h3 className='text-lg font-semibold mb-4 text-sage-900'>
+                <h3 className='text-lg font-semibold mb-4 text-sage-900 dark:text-slate-100'>
                   Interested in Working Together?
                 </h3>
-                <p className='text-sage-700 mb-6'>
+                <p className='text-sage-700 dark:text-slate-300 mb-6'>
                   I&apos;m always excited to work on new projects and
                   collaborate with innovative teams. Let&apos;s discuss how we
                   can bring your ideas to life.
                 </p>
                 <Link
                   href='/#contact'
-                  className='inline-flex items-center px-6 py-3 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 transition-colors font-medium'
+                  className='inline-flex items-center px-6 py-3 bg-emerald-600 dark:bg-emerald-500 text-white rounded-lg hover:bg-emerald-700 dark:hover:bg-emerald-400 transition-colors font-medium'
                 >
                   Get In Touch
                 </Link>

--- a/components/about.tsx
+++ b/components/about.tsx
@@ -26,13 +26,13 @@ export default function About() {
   ];
 
   return (
-    <section id='about' className='py-20 bg-emerald-50/30'>
+    <section id='about' className='py-20 bg-emerald-50/30 dark:bg-[#0f1a16]'>
       <div className='container mx-auto px-4 sm:px-6 lg:px-8'>
         <div className='text-center mb-16'>
-          <h2 className='text-3xl sm:text-4xl font-bold mb-4 text-sage-900'>
+          <h2 className='text-3xl sm:text-4xl font-bold mb-4 text-sage-900 dark:text-slate-100'>
             About Me
           </h2>
-          <p className='text-lg text-sage-700 max-w-2xl mx-auto'>
+          <p className='text-lg text-sage-700 dark:text-slate-300 max-w-2xl mx-auto'>
             A passionate software engineer dedicated to creating innovative
             solutions and leading high-performing development teams.
           </p>
@@ -42,14 +42,18 @@ export default function About() {
           {highlights.map((item, index) => (
             <Card
               key={index}
-              className='text-center p-6 card-elegant hover-lift'
+              className='text-center p-6 card-elegant hover-lift glow-emerald'
             >
               <CardContent className='space-y-4'>
-                <div className='mx-auto w-12 h-12 bg-emerald-100 rounded-lg flex items-center justify-center'>
-                  <item.icon className='h-6 w-6 text-emerald-600' />
+                <div className='mx-auto w-12 h-12 bg-emerald-100 dark:bg-emerald-900/30 rounded-lg flex items-center justify-center'>
+                  <item.icon className='h-6 w-6 text-emerald-600 dark:text-emerald-400' />
                 </div>
-                <h3 className='font-semibold text-sage-900'>{item.title}</h3>
-                <p className='text-sm text-sage-600'>{item.description}</p>
+                <h3 className='font-semibold text-sage-900 dark:text-slate-100'>
+                  {item.title}
+                </h3>
+                <p className='text-sm text-sage-600 dark:text-slate-400'>
+                  {item.description}
+                </p>
               </CardContent>
             </Card>
           ))}
@@ -57,14 +61,14 @@ export default function About() {
 
         <div className='max-w-4xl mx-auto'>
           <div className='prose prose-lg max-w-none'>
-            <p className='text-sage-700 leading-relaxed mb-6'>
+            <p className='text-sage-700 dark:text-slate-300 leading-relaxed mb-6'>
               I am a passionate Full-Stack Software Engineer with over 5 years
               of experience in developing and maintaining robust applications
               using cutting-edge technologies. My expertise spans across Golang,
               Ruby on Rails, and JavaScript ecosystems, with a strong focus on
               delivering high-quality software solutions.
             </p>
-            <p className='text-sage-700 leading-relaxed mb-6'>
+            <p className='text-sage-700 dark:text-slate-300 leading-relaxed mb-6'>
               Throughout my career at Pernix Solutions, I have progressed from
               an Apprentice to Software Engineer III and Supervisor of the
               Apprentice Program. This journey has given me unique insights into
@@ -72,7 +76,7 @@ export default function About() {
               mentor new talent while leading complex projects from conception
               to completion.
             </p>
-            <p className='text-sage-700 leading-relaxed'>
+            <p className='text-sage-700 dark:text-slate-300 leading-relaxed'>
               I thrive in collaborative environments, having worked with
               international teams across the US, Colombia, Australia, and India.
               Currently pursuing an MBA with a focus on Project Management, I am

--- a/components/awards.tsx
+++ b/components/awards.tsx
@@ -3,38 +3,38 @@ import { Trophy, Star } from 'lucide-react';
 
 export default function Awards() {
   return (
-    <section className='py-20 bg-emerald-50/30'>
+    <section className='py-20 bg-emerald-50/30 dark:bg-[#0f1a16]'>
       <div className='container mx-auto px-4 sm:px-6 lg:px-8'>
         <div className='text-center mb-16'>
-          <h2 className='text-3xl sm:text-4xl font-bold mb-4 text-sage-900'>
+          <h2 className='text-3xl sm:text-4xl font-bold mb-4 text-sage-900 dark:text-slate-100'>
             Awards & Recognition
           </h2>
-          <p className='text-lg text-sage-700 max-w-2xl mx-auto'>
+          <p className='text-lg text-sage-700 dark:text-slate-300 max-w-2xl mx-auto'>
             Recognition for excellence in software development and programming
             competitions.
           </p>
         </div>
 
         <div className='max-w-2xl mx-auto'>
-          <Card className='relative overflow-hidden card-elegant hover-lift'>
-            <div className='absolute top-0 right-0 w-32 h-32 bg-gradient-to-br from-emerald-200/40 to-emerald-300/40 rounded-full -translate-y-16 translate-x-16'></div>
+          <Card className='relative overflow-hidden card-elegant hover-lift glow-emerald'>
+            <div className='absolute top-0 right-0 w-32 h-32 bg-gradient-to-br from-emerald-200/40 to-emerald-300/40 dark:from-emerald-900/20 dark:to-emerald-800/10 rounded-full -translate-y-16 translate-x-16'></div>
             <CardHeader className='relative'>
               <div className='flex items-center gap-4'>
-                <div className='w-16 h-16 bg-gradient-to-br from-emerald-500 to-emerald-600 rounded-full flex items-center justify-center shadow-lg'>
+                <div className='w-16 h-16 bg-gradient-to-br from-emerald-500 to-emerald-600 dark:from-emerald-600 dark:to-emerald-500 rounded-full flex items-center justify-center shadow-lg dark:shadow-emerald-500/20'>
                   <Trophy className='h-8 w-8 text-white' />
                 </div>
                 <div>
-                  <CardTitle className='text-xl text-sage-900'>
+                  <CardTitle className='text-xl text-sage-900 dark:text-slate-100'>
                     2020 Programathon Competition Winner
                   </CardTitle>
-                  <p className='text-sage-700'>
+                  <p className='text-sage-700 dark:text-slate-300'>
                     Costa Rica&apos;s Most Prestigious Programming Competition
                   </p>
                 </div>
               </div>
             </CardHeader>
             <CardContent className='space-y-4'>
-              <p className='text-sage-700'>
+              <p className='text-sage-700 dark:text-slate-300'>
                 Winner of the 2020 Programathon Competition, the most
                 prestigious programming competition in Costa Rica, sponsored by
                 Fiserv. This achievement demonstrates exceptional
@@ -43,8 +43,8 @@ export default function Awards() {
               </p>
 
               <div className='flex items-center gap-2 pt-4'>
-                <Star className='h-4 w-4 text-emerald-500 fill-current' />
-                <span className='text-sm font-medium text-emerald-700'>
+                <Star className='h-4 w-4 text-emerald-500 dark:text-emerald-400 fill-current' />
+                <span className='text-sm font-medium text-emerald-700 dark:text-emerald-400'>
                   Sponsored by Fiserv
                 </span>
               </div>

--- a/components/blog-post-card.tsx
+++ b/components/blog-post-card.tsx
@@ -23,7 +23,7 @@ export default function BlogPostCard({ post, index }: BlogPostCardProps) {
 
   return (
     <Card
-      className={`card-elegant hover-lift transition-all duration-300 transform ${
+      className={`card-elegant hover-lift glow-emerald transition-all duration-300 transform ${
         isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
       }`}
     >
@@ -33,18 +33,18 @@ export default function BlogPostCard({ post, index }: BlogPostCardProps) {
             <Badge
               key={tag}
               variant='secondary'
-              className='text-xs bg-emerald-100 text-emerald-700 hover:bg-emerald-200 transition-colors'
+              className='text-xs bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400 hover:bg-emerald-200 dark:hover:bg-emerald-900/50 transition-colors'
             >
               {tag}
             </Badge>
           ))}
         </div>
-        <CardTitle className='text-xl text-sage-900 hover:text-emerald-700 transition-colors'>
+        <CardTitle className='text-xl text-sage-900 dark:text-slate-100 hover:text-emerald-700 dark:hover:text-emerald-400 transition-colors'>
           <Link href={`/blog/${post.slug}`} className='block group'>
             <span className='group-hover:underline'>{post.title}</span>
           </Link>
         </CardTitle>
-        <div className='flex items-center gap-4 text-sm text-sage-600'>
+        <div className='flex items-center gap-4 text-sm text-sage-600 dark:text-slate-400'>
           <div className='flex items-center gap-1'>
             <Calendar className='h-4 w-4' />
             <span>
@@ -62,12 +62,12 @@ export default function BlogPostCard({ post, index }: BlogPostCardProps) {
         </div>
       </CardHeader>
       <CardContent>
-        <p className='text-sage-700 mb-4 leading-relaxed line-clamp-3'>
+        <p className='text-sage-700 dark:text-slate-300 mb-4 leading-relaxed line-clamp-3'>
           {post.excerpt}
         </p>
         <Link
           href={`/blog/${post.slug}`}
-          className='inline-flex items-center gap-2 text-emerald-600 hover:text-emerald-700 font-medium transition-colors group'
+          className='inline-flex items-center gap-2 text-emerald-600 dark:text-emerald-400 hover:text-emerald-700 dark:hover:text-emerald-300 font-medium transition-colors group'
         >
           <span>Read full article</span>
           <ArrowRight className='h-4 w-4 transition-transform group-hover:translate-x-1' />

--- a/components/contact.tsx
+++ b/components/contact.tsx
@@ -28,13 +28,13 @@ export default function Contact() {
   ];
 
   return (
-    <section id='contact' className='py-20 bg-white'>
+    <section id='contact' className='py-20 bg-white dark:bg-background'>
       <div className='container mx-auto px-4 sm:px-6 lg:px-8'>
         <div className='text-center mb-16'>
-          <h2 className='text-3xl sm:text-4xl font-bold mb-4 text-sage-900'>
+          <h2 className='text-3xl sm:text-4xl font-bold mb-4 text-sage-900 dark:text-slate-100'>
             Get In Touch
           </h2>
-          <p className='text-lg text-sage-700 max-w-2xl mx-auto'>
+          <p className='text-lg text-sage-700 dark:text-slate-300 max-w-2xl mx-auto'>
             Ready to collaborate on your next project? Let&apos;s discuss how we
             can work together to bring your ideas to life.
           </p>
@@ -45,20 +45,20 @@ export default function Contact() {
             {contactInfo.map((item, index) => (
               <Card
                 key={index}
-                className='text-center p-6 card-elegant hover-lift'
+                className='text-center p-6 card-elegant hover-lift glow-emerald'
               >
                 <CardContent className='space-y-4'>
-                  <div className='mx-auto w-16 h-16 bg-emerald-100 rounded-lg flex items-center justify-center'>
-                    <item.icon className='h-8 w-8 text-emerald-600' />
+                  <div className='mx-auto w-16 h-16 bg-emerald-100 dark:bg-emerald-900/30 rounded-lg flex items-center justify-center'>
+                    <item.icon className='h-8 w-8 text-emerald-600 dark:text-emerald-400' />
                   </div>
                   <div>
-                    <h3 className='font-semibold text-lg mb-2 text-sage-900'>
+                    <h3 className='font-semibold text-lg mb-2 text-sage-900 dark:text-slate-100'>
                       {item.label}
                     </h3>
                     {item.href ? (
                       <Link
                         href={item.href}
-                        className='text-sage-700 hover:text-emerald-600 transition-colors text-sm'
+                        className='text-sage-700 dark:text-slate-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors text-sm'
                         target={
                           item.href.startsWith('http') ? '_blank' : undefined
                         }
@@ -71,7 +71,9 @@ export default function Contact() {
                         {item.value}
                       </Link>
                     ) : (
-                      <p className='text-sage-700 text-sm'>{item.value}</p>
+                      <p className='text-sage-700 dark:text-slate-300 text-sm'>
+                        {item.value}
+                      </p>
                     )}
                   </div>
                 </CardContent>
@@ -80,7 +82,7 @@ export default function Contact() {
           </div>
 
           <div className='text-center mt-12'>
-            <p className='text-sage-700'>
+            <p className='text-sage-700 dark:text-slate-300'>
               Ready to collaborate on your next project? Feel free to reach out
               via email or connect with me on LinkedIn.
             </p>

--- a/components/education.tsx
+++ b/components/education.tsx
@@ -47,13 +47,13 @@ export default function Education() {
   ];
 
   return (
-    <section id='education' className='py-20 bg-white'>
+    <section id='education' className='py-20 bg-white dark:bg-background'>
       <div className='container mx-auto px-4 sm:px-6 lg:px-8'>
         <div className='text-center mb-16'>
-          <h2 className='text-3xl sm:text-4xl font-bold mb-4 text-sage-900'>
+          <h2 className='text-3xl sm:text-4xl font-bold mb-4 text-sage-900 dark:text-slate-100'>
             Education & Certifications
           </h2>
-          <p className='text-lg text-sage-700 max-w-2xl mx-auto'>
+          <p className='text-lg text-sage-700 dark:text-slate-300 max-w-2xl mx-auto'>
             Continuous learning and professional development through formal
             education and specialized certifications.
           </p>
@@ -62,16 +62,19 @@ export default function Education() {
         <div className='max-w-4xl mx-auto space-y-8'>
           {/* Education */}
           <div>
-            <h3 className='text-2xl font-semibold mb-6 flex items-center gap-2 text-emerald-800'>
-              <GraduationCap className='h-6 w-6 text-emerald-600' />
+            <h3 className='text-2xl font-semibold mb-6 flex items-center gap-2 text-emerald-800 dark:text-emerald-400'>
+              <GraduationCap className='h-6 w-6 text-emerald-600 dark:text-emerald-400' />
               Education
             </h3>
             <div className='space-y-4'>
               {education.map((edu, index) => (
-                <Card key={index} className='card-elegant hover-lift'>
+                <Card
+                  key={index}
+                  className='card-elegant hover-lift glow-emerald'
+                >
                   <CardHeader>
                     <div className='flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2'>
-                      <CardTitle className='text-lg text-sage-900'>
+                      <CardTitle className='text-lg text-sage-900 dark:text-slate-100'>
                         {edu.degree}
                       </CardTitle>
                       <div className='flex items-center gap-2'>
@@ -81,15 +84,15 @@ export default function Education() {
                           }
                           className={
                             edu.status === 'current'
-                              ? 'bg-emerald-600 text-white'
-                              : 'bg-emerald-100 text-emerald-700'
+                              ? 'bg-emerald-600 dark:bg-emerald-500 text-white'
+                              : 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400'
                           }
                         >
                           {edu.status === 'current'
                             ? 'In Progress'
                             : 'Completed'}
                         </Badge>
-                        <div className='flex items-center gap-1 text-sm text-sage-600'>
+                        <div className='flex items-center gap-1 text-sm text-sage-600 dark:text-slate-400'>
                           <Calendar className='h-4 w-4' />
                           <span>{edu.period}</span>
                         </div>
@@ -97,7 +100,9 @@ export default function Education() {
                     </div>
                   </CardHeader>
                   <CardContent>
-                    <p className='text-sage-700'>{edu.institution}</p>
+                    <p className='text-sage-700 dark:text-slate-300'>
+                      {edu.institution}
+                    </p>
                   </CardContent>
                 </Card>
               ))}
@@ -106,25 +111,28 @@ export default function Education() {
 
           {/* Certifications */}
           <div>
-            <h3 className='text-2xl font-semibold mb-6 flex items-center gap-2 text-emerald-800'>
-              <Award className='h-6 w-6 text-emerald-600' />
+            <h3 className='text-2xl font-semibold mb-6 flex items-center gap-2 text-emerald-800 dark:text-emerald-400'>
+              <Award className='h-6 w-6 text-emerald-600 dark:text-emerald-400' />
               Certifications
             </h3>
             <div className='grid md:grid-cols-2 gap-4'>
               {certifications.map((cert, index) => (
-                <Card key={index} className='card-elegant hover-lift'>
+                <Card
+                  key={index}
+                  className='card-elegant hover-lift glow-emerald'
+                >
                   <CardHeader>
-                    <CardTitle className='text-base text-sage-900'>
+                    <CardTitle className='text-base text-sage-900 dark:text-slate-100'>
                       {cert.title}
                     </CardTitle>
                   </CardHeader>
                   <CardContent>
-                    <p className='text-sm text-sage-700 mb-2'>
+                    <p className='text-sm text-sage-700 dark:text-slate-300 mb-2'>
                       {cert.institution}
                     </p>
                     <Badge
                       variant='outline'
-                      className='text-xs border-emerald-300 text-emerald-700'
+                      className='text-xs border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-400'
                     >
                       {cert.year}
                     </Badge>

--- a/components/enhanced-navigation.tsx
+++ b/components/enhanced-navigation.tsx
@@ -72,6 +72,7 @@ export default function EnhancedNavigation() {
                 <div key={item.href}>
                   {item.type === 'blog' ? (
                     <button
+                      type='button'
                       onClick={() => handleNavClick(item)}
                       className='text-sage-600 dark:text-slate-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors font-medium'
                     >
@@ -116,6 +117,7 @@ export default function EnhancedNavigation() {
                 <div key={item.href}>
                   {item.type === 'blog' ? (
                     <button
+                      type='button'
                       onClick={() => handleNavClick(item)}
                       className='text-sage-600 dark:text-slate-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors font-medium text-left'
                     >

--- a/components/enhanced-navigation.tsx
+++ b/components/enhanced-navigation.tsx
@@ -52,13 +52,16 @@ export default function EnhancedNavigation() {
     <nav
       className={`fixed top-0 w-full z-50 transition-all duration-300 ${
         scrolled
-          ? 'bg-white/95 backdrop-blur-sm border-b border-emerald-100'
+          ? 'bg-white/95 dark:bg-black/70 backdrop-blur-xl border-b border-emerald-100 dark:border-emerald-900/20'
           : 'bg-transparent'
       }`}
     >
       <div className='container mx-auto px-4 sm:px-6 lg:px-8'>
         <div className='flex justify-between items-center py-4'>
-          <Link href='/' className='text-xl font-bold text-emerald-600'>
+          <Link
+            href='/'
+            className='text-xl font-bold text-emerald-600 dark:text-emerald-400'
+          >
             Geovanny Cordero
           </Link>
 
@@ -70,14 +73,14 @@ export default function EnhancedNavigation() {
                   {item.type === 'blog' ? (
                     <button
                       onClick={() => handleNavClick(item)}
-                      className='text-sage-600 hover:text-emerald-600 transition-colors font-medium'
+                      className='text-sage-600 dark:text-slate-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors font-medium'
                     >
                       {item.label}
                     </button>
                   ) : (
                     <Link
                       href={item.href}
-                      className='text-sage-600 hover:text-emerald-600 transition-colors font-medium'
+                      className='text-sage-600 dark:text-slate-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors font-medium'
                       onClick={() => setIsOpen(false)}
                     >
                       {item.label}
@@ -93,7 +96,7 @@ export default function EnhancedNavigation() {
             <Button
               variant='ghost'
               size='icon'
-              className='text-sage-600 hover:text-emerald-600'
+              className='text-sage-600 dark:text-slate-300 hover:text-emerald-600 dark:hover:text-emerald-400'
               onClick={() => setIsOpen(!isOpen)}
             >
               {isOpen ? (
@@ -107,21 +110,21 @@ export default function EnhancedNavigation() {
 
         {/* Mobile Navigation Menu */}
         {isOpen && (
-          <div className='md:hidden pb-4 bg-white/95 backdrop-blur-sm border-t border-emerald-100'>
+          <div className='md:hidden pb-4 bg-white/95 dark:bg-black/80 backdrop-blur-xl border-t border-emerald-100 dark:border-emerald-900/20'>
             <div className='flex flex-col space-y-4 pt-4'>
               {navItems.map(item => (
                 <div key={item.href}>
                   {item.type === 'blog' ? (
                     <button
                       onClick={() => handleNavClick(item)}
-                      className='text-sage-600 hover:text-emerald-600 transition-colors font-medium text-left'
+                      className='text-sage-600 dark:text-slate-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors font-medium text-left'
                     >
                       {item.label}
                     </button>
                   ) : (
                     <Link
                       href={item.href}
-                      className='text-sage-600 hover:text-emerald-600 transition-colors font-medium'
+                      className='text-sage-600 dark:text-slate-300 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors font-medium'
                       onClick={() => setIsOpen(false)}
                     >
                       {item.label}

--- a/components/experience.tsx
+++ b/components/experience.tsx
@@ -4,28 +4,31 @@ import { Calendar, MapPin } from 'lucide-react';
 
 export default function Experience() {
   return (
-    <section id='experience' className='py-20 bg-emerald-50/30'>
+    <section
+      id='experience'
+      className='py-20 bg-emerald-50/30 dark:bg-[#0f1a16]'
+    >
       <div className='container mx-auto px-4 sm:px-6 lg:px-8'>
         <div className='text-center mb-16'>
-          <h2 className='text-3xl sm:text-4xl font-bold mb-4 text-sage-900'>
+          <h2 className='text-3xl sm:text-4xl font-bold mb-4 text-sage-900 dark:text-slate-100'>
             Work Experience
           </h2>
-          <p className='text-lg text-sage-700 max-w-2xl mx-auto'>
+          <p className='text-lg text-sage-700 dark:text-slate-300 max-w-2xl mx-auto'>
             My professional journey showcasing growth, leadership, and technical
             excellence.
           </p>
         </div>
 
         <div className='max-w-4xl mx-auto'>
-          <Card className='relative card-elegant'>
-            <div className='absolute left-8 top-8 bottom-8 w-0.5 bg-emerald-200'></div>
+          <Card className='relative card-elegant glow-emerald'>
+            <div className='absolute left-8 top-8 bottom-8 w-0.5 bg-emerald-200 dark:bg-emerald-800'></div>
             <CardHeader className='relative pl-16'>
-              <div className='absolute left-6 top-8 w-4 h-4 bg-emerald-600 rounded-full border-4 border-white shadow-md'></div>
+              <div className='absolute left-6 top-8 w-4 h-4 bg-emerald-600 dark:bg-emerald-400 rounded-full border-4 border-white dark:border-[#0f1a16] shadow-md'></div>
               <div className='flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2'>
-                <CardTitle className='text-xl text-sage-900'>
+                <CardTitle className='text-xl text-sage-900 dark:text-slate-100'>
                   Pernix Solutions
                 </CardTitle>
-                <div className='flex items-center gap-4 text-sm text-sage-600'>
+                <div className='flex items-center gap-4 text-sm text-sage-600 dark:text-slate-400'>
                   <div className='flex items-center gap-1'>
                     <Calendar className='h-4 w-4' />
                     <span>July 2019 - Present</span>
@@ -39,60 +42,60 @@ export default function Experience() {
               <div className='flex flex-wrap gap-2 mt-2'>
                 <Badge
                   variant='outline'
-                  className='border-emerald-300 text-emerald-700'
+                  className='border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-400'
                 >
                   Software Engineer III
                 </Badge>
                 <Badge
                   variant='outline'
-                  className='border-emerald-300 text-emerald-700'
+                  className='border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-400'
                 >
                   Apprentice Program Supervisor
                 </Badge>
               </div>
             </CardHeader>
             <CardContent className='pl-16 space-y-4'>
-              <p className='text-sage-700'>
+              <p className='text-sage-700 dark:text-slate-300'>
                 Progressed from Apprentice to Software Engineer III and
                 Supervisor of the Apprentice Program, demonstrating exceptional
                 growth and leadership capabilities.
               </p>
 
               <div className='space-y-3'>
-                <h4 className='font-semibold text-emerald-800'>
+                <h4 className='font-semibold text-emerald-800 dark:text-emerald-400'>
                   Key Achievements:
                 </h4>
-                <ul className='space-y-2 text-sage-700'>
+                <ul className='space-y-2 text-sage-700 dark:text-slate-300'>
                   <li className='flex items-start gap-2'>
-                    <span className='w-1.5 h-1.5 bg-emerald-600 rounded-full mt-2 flex-shrink-0'></span>
+                    <span className='w-1.5 h-1.5 bg-emerald-600 dark:bg-emerald-400 rounded-full mt-2 flex-shrink-0'></span>
                     <span>
                       Developed and maintained full-stack applications using
                       Golang, Ruby on Rails, and Vue.js
                     </span>
                   </li>
                   <li className='flex items-start gap-2'>
-                    <span className='w-1.5 h-1.5 bg-emerald-600 rounded-full mt-2 flex-shrink-0'></span>
+                    <span className='w-1.5 h-1.5 bg-emerald-600 dark:bg-emerald-400 rounded-full mt-2 flex-shrink-0'></span>
                     <span>
                       Led end-to-end software projects including requirement
                       gathering, estimation, development, and delivery
                     </span>
                   </li>
                   <li className='flex items-start gap-2'>
-                    <span className='w-1.5 h-1.5 bg-emerald-600 rounded-full mt-2 flex-shrink-0'></span>
+                    <span className='w-1.5 h-1.5 bg-emerald-600 dark:bg-emerald-400 rounded-full mt-2 flex-shrink-0'></span>
                     <span>
                       Collaborated with international teams from the US,
                       Colombia, Australia, and India
                     </span>
                   </li>
                   <li className='flex items-start gap-2'>
-                    <span className='w-1.5 h-1.5 bg-emerald-600 rounded-full mt-2 flex-shrink-0'></span>
+                    <span className='w-1.5 h-1.5 bg-emerald-600 dark:bg-emerald-400 rounded-full mt-2 flex-shrink-0'></span>
                     <span>
                       Managed and mentored new apprentices, supporting their
                       personal and professional development
                     </span>
                   </li>
                   <li className='flex items-start gap-2'>
-                    <span className='w-1.5 h-1.5 bg-emerald-600 rounded-full mt-2 flex-shrink-0'></span>
+                    <span className='w-1.5 h-1.5 bg-emerald-600 dark:bg-emerald-400 rounded-full mt-2 flex-shrink-0'></span>
                     <span>
                       Spearheaded multiple teams as Developer, Team Lead, and
                       Manager
@@ -102,7 +105,7 @@ export default function Experience() {
               </div>
 
               <div className='pt-4'>
-                <h4 className='font-semibold mb-2 text-emerald-800'>
+                <h4 className='font-semibold mb-2 text-emerald-800 dark:text-emerald-400'>
                   Technologies Used:
                 </h4>
                 <div className='flex flex-wrap gap-2'>
@@ -119,7 +122,7 @@ export default function Experience() {
                     <Badge
                       key={tech}
                       variant='secondary'
-                      className='text-xs bg-emerald-100 text-emerald-700'
+                      className='text-xs bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400'
                     >
                       {tech}
                     </Badge>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -5,21 +5,21 @@ import RSSLink from './rss-link';
 
 export default function Footer() {
   return (
-    <footer className='bg-emerald-50/50 border-t border-emerald-100'>
+    <footer className='bg-emerald-50/50 dark:bg-black/80 border-t border-emerald-100 dark:border-emerald-900/20'>
       <div className='container mx-auto px-4 sm:px-6 lg:px-8 py-12'>
         <div className='grid md:grid-cols-3 gap-8'>
           <div>
-            <h3 className='text-lg font-semibold mb-4 text-sage-900'>
+            <h3 className='text-lg font-semibold mb-4 text-sage-900 dark:text-slate-100'>
               Geovanny Cordero Valverde
             </h3>
-            <p className='text-sage-700 mb-4'>
+            <p className='text-sage-700 dark:text-slate-400 mb-4'>
               Full-Stack Software Engineer passionate about creating innovative
               solutions and leading high-performing development teams.
             </p>
             <div className='flex gap-4'>
               <Link
                 href='mailto:geovanny@pm.me'
-                className='text-sage-600 hover:text-emerald-600 transition-colors'
+                className='text-sage-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors'
               >
                 <Mail className='h-5 w-5' />
               </Link>
@@ -27,7 +27,7 @@ export default function Footer() {
                 href='https://linkedin.com/in/geovannycordero'
                 target='_blank'
                 rel='noopener noreferrer'
-                className='text-sage-600 hover:text-emerald-600 transition-colors'
+                className='text-sage-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors'
               >
                 <Linkedin className='h-5 w-5' />
               </Link>
@@ -35,7 +35,7 @@ export default function Footer() {
                 href='https://github.com/geovannycordero'
                 target='_blank'
                 rel='noopener noreferrer'
-                className='text-sage-600 hover:text-emerald-600 transition-colors'
+                className='text-sage-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors'
               >
                 <Github className='h-5 w-5' />
               </Link>
@@ -43,7 +43,7 @@ export default function Footer() {
                 href='https://x.com/gehovah'
                 target='_blank'
                 rel='noopener noreferrer'
-                className='text-sage-600 hover:text-emerald-600 transition-colors'
+                className='text-sage-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors'
                 aria-label='Visit X profile'
               >
                 <svg
@@ -59,41 +59,43 @@ export default function Footer() {
           </div>
 
           <div>
-            <h4 className='font-semibold mb-4 text-emerald-800'>Quick Links</h4>
+            <h4 className='font-semibold mb-4 text-emerald-800 dark:text-emerald-400'>
+              Quick Links
+            </h4>
             <nav className='space-y-2'>
               <Link
                 href='/#about'
-                className='block text-sage-600 hover:text-emerald-600 transition-colors'
+                className='block text-sage-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors'
               >
                 About
               </Link>
               <Link
                 href='/#skills'
-                className='block text-sage-600 hover:text-emerald-600 transition-colors'
+                className='block text-sage-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors'
               >
                 Skills
               </Link>
               <Link
                 href='/#experience'
-                className='block text-sage-600 hover:text-emerald-600 transition-colors'
+                className='block text-sage-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors'
               >
                 Experience
               </Link>
               <Link
                 href='/#education'
-                className='block text-sage-600 hover:text-emerald-600 transition-colors'
+                className='block text-sage-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors'
               >
                 Education
               </Link>
               <Link
                 href='/#contact'
-                className='block text-sage-600 hover:text-emerald-600 transition-colors'
+                className='block text-sage-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors'
               >
                 Contact
               </Link>
               <Link
                 href='/projects'
-                className='block text-sage-600 hover:text-emerald-600 transition-colors'
+                className='block text-sage-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors'
               >
                 Projects
               </Link>
@@ -104,8 +106,10 @@ export default function Footer() {
           </div>
 
           <div>
-            <h4 className='font-semibold mb-4 text-emerald-800'>Services</h4>
-            <ul className='space-y-2 text-sage-600'>
+            <h4 className='font-semibold mb-4 text-emerald-800 dark:text-emerald-400'>
+              Services
+            </h4>
+            <ul className='space-y-2 text-sage-600 dark:text-slate-400'>
               <li>Full-Stack Development</li>
               <li>Team Leadership</li>
               <li>Project Management</li>
@@ -115,7 +119,7 @@ export default function Footer() {
           </div>
         </div>
 
-        <div className='border-t border-emerald-100 mt-8 pt-8 text-center text-sage-600'>
+        <div className='border-t border-emerald-100 dark:border-emerald-900/20 mt-8 pt-8 text-center text-sage-600 dark:text-slate-500'>
           <p>
             &copy; {new Date().getFullYear()} Geovanny Cordero Valverde. All
             rights reserved.

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -11,20 +11,22 @@ export default function Hero() {
         <div className='grid lg:grid-cols-2 gap-12 items-center'>
           <div className='space-y-8'>
             <div className='space-y-4'>
-              <h1 className='text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-sage-900'>
+              <h1 className='text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-sage-900 dark:text-slate-100'>
                 Geovanny
-                <span className='block text-emerald-600'>Cordero</span>
+                <span className='block text-emerald-600 dark:bg-gradient-to-r dark:from-emerald-400 dark:to-cyan-400 dark:bg-clip-text dark:text-transparent'>
+                  Cordero
+                </span>
               </h1>
-              <p className='text-xl sm:text-2xl text-emerald-700 font-medium'>
+              <p className='text-xl sm:text-2xl text-emerald-700 dark:text-emerald-400 font-medium'>
                 Full-Stack Software Engineer
               </p>
-              <div className='flex items-center gap-2 text-sage-600'>
+              <div className='flex items-center gap-2 text-sage-600 dark:text-slate-400'>
                 <MapPin className='h-4 w-4' />
                 <span>San José, Costa Rica</span>
               </div>
             </div>
 
-            <p className='text-lg text-sage-700 leading-relaxed'>
+            <p className='text-lg text-sage-700 dark:text-slate-300 leading-relaxed'>
               Passionate Full-Stack Software Engineer with 5+ years of
               experience, specializing in Golang, Ruby on Rails, and JavaScript
               technologies. Proven expertise in leading teams and delivering
@@ -35,7 +37,7 @@ export default function Hero() {
               <Button
                 asChild
                 size='lg'
-                className='bg-emerald-600 hover:bg-emerald-700 text-white shadow-lg hover:shadow-xl transition-all duration-300'
+                className='bg-emerald-600 hover:bg-emerald-500 dark:bg-emerald-500 dark:hover:bg-emerald-400 text-white shadow-lg dark:shadow-emerald-500/20 hover:shadow-xl dark:hover:shadow-emerald-500/40 transition-all duration-300'
               >
                 <Link href='/#contact'>Get In Touch</Link>
               </Button>
@@ -43,7 +45,7 @@ export default function Hero() {
                 variant='outline'
                 size='lg'
                 asChild
-                className='border-emerald-600 text-emerald-600 hover:bg-emerald-50 hover:text-emerald-700 transition-all duration-300'
+                className='border-emerald-600 dark:border-emerald-600 text-emerald-600 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/20 hover:text-emerald-700 dark:hover:text-emerald-300 transition-all duration-300'
               >
                 <Link href='/#about'>Learn More</Link>
               </Button>
@@ -52,7 +54,7 @@ export default function Hero() {
             <div className='flex flex-wrap gap-6 pt-4'>
               <Link
                 href='mailto:geovanny@pm.me'
-                className='flex items-center gap-2 text-sage-600 hover:text-emerald-600 transition-colors duration-200'
+                className='flex items-center gap-2 text-sage-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors duration-200'
               >
                 <Mail className='h-4 w-4' />
                 <span className='hidden sm:inline'>geovanny@pm.me</span>
@@ -61,7 +63,7 @@ export default function Hero() {
                 href='https://linkedin.com/in/geovannycordero'
                 target='_blank'
                 rel='noopener noreferrer'
-                className='flex items-center gap-2 text-sage-600 hover:text-emerald-600 transition-colors duration-200'
+                className='flex items-center gap-2 text-sage-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors duration-200'
               >
                 <Linkedin className='h-4 w-4' />
                 <span className='hidden sm:inline'>LinkedIn</span>
@@ -70,7 +72,7 @@ export default function Hero() {
                 href='https://github.com/geovannycordero'
                 target='_blank'
                 rel='noopener noreferrer'
-                className='flex items-center gap-2 text-sage-600 hover:text-emerald-600 transition-colors duration-200'
+                className='flex items-center gap-2 text-sage-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors duration-200'
                 aria-label='Visit GitHub profile'
               >
                 <Github className='h-4 w-4' />
@@ -80,7 +82,7 @@ export default function Hero() {
                 href='https://x.com/gehovah'
                 target='_blank'
                 rel='noopener noreferrer'
-                className='flex items-center gap-2 text-sage-600 hover:text-emerald-600 transition-colors duration-200'
+                className='flex items-center gap-2 text-sage-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors duration-200'
                 aria-label='Visit X profile'
               >
                 <svg
@@ -97,7 +99,7 @@ export default function Hero() {
 
           <div className='flex justify-center lg:justify-end'>
             <div className='relative'>
-              <div className='w-80 h-80 rounded-2xl bg-gradient-to-br from-emerald-100 to-emerald-200 flex items-center justify-center overflow-hidden shadow-2xl hover-lift'>
+              <div className='w-80 h-80 rounded-2xl bg-gradient-to-br from-emerald-100 to-emerald-200 dark:from-emerald-900/30 dark:to-emerald-800/10 flex items-center justify-center overflow-hidden shadow-2xl dark:shadow-emerald-500/10 hover-lift'>
                 <Image
                   src='/images/me-forest.jpg'
                   alt='Geovanny Cordero Valverde on a forest bridge'
@@ -108,8 +110,8 @@ export default function Hero() {
                 />
               </div>
               {/* Decorative elements */}
-              <div className='absolute -top-4 -right-4 w-24 h-24 bg-emerald-200 rounded-full opacity-60 blur-xl'></div>
-              <div className='absolute -bottom-4 -left-4 w-32 h-32 bg-emerald-300 rounded-full opacity-40 blur-xl'></div>
+              <div className='absolute -top-4 -right-4 w-24 h-24 bg-emerald-200 dark:bg-emerald-500 rounded-full opacity-60 dark:opacity-20 blur-xl'></div>
+              <div className='absolute -bottom-4 -left-4 w-32 h-32 bg-emerald-300 dark:bg-emerald-600 rounded-full opacity-40 dark:opacity-15 blur-xl'></div>
             </div>
           </div>
         </div>

--- a/components/project-card.tsx
+++ b/components/project-card.tsx
@@ -25,7 +25,7 @@ export default function ProjectCard({ project, index }: ProjectCardProps) {
 
   return (
     <Card
-      className={`card-elegant hover-lift transition-all duration-300 transform ${
+      className={`card-elegant hover-lift glow-emerald transition-all duration-300 transform ${
         isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
       }`}
     >
@@ -40,7 +40,7 @@ export default function ProjectCard({ project, index }: ProjectCardProps) {
         <div className='absolute inset-0 bg-gradient-to-t from-black/20 to-transparent' />
         {project.featured && (
           <div className='absolute top-3 right-3'>
-            <Badge className='bg-emerald-600 text-white text-xs'>
+            <Badge className='bg-emerald-600 dark:bg-emerald-500 text-white text-xs'>
               Featured
             </Badge>
           </div>
@@ -49,10 +49,10 @@ export default function ProjectCard({ project, index }: ProjectCardProps) {
 
       <CardHeader className='pb-3'>
         <div className='flex items-start justify-between gap-2'>
-          <CardTitle className='text-xl text-sage-900 hover:text-emerald-700 transition-colors line-clamp-2'>
+          <CardTitle className='text-xl text-sage-900 dark:text-slate-100 hover:text-emerald-700 dark:hover:text-emerald-400 transition-colors line-clamp-2'>
             {project.title}
           </CardTitle>
-          <div className='flex items-center gap-1 text-xs text-sage-600'>
+          <div className='flex items-center gap-1 text-xs text-sage-600 dark:text-slate-400'>
             <Calendar className='h-3 w-3' />
             <span>{project.completedDate}</span>
           </div>
@@ -61,7 +61,7 @@ export default function ProjectCard({ project, index }: ProjectCardProps) {
         <div className='flex flex-wrap gap-2'>
           <Badge
             variant='outline'
-            className='text-xs border-emerald-300 text-emerald-700'
+            className='text-xs border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-400'
           >
             {project.category}
           </Badge>
@@ -69,7 +69,7 @@ export default function ProjectCard({ project, index }: ProjectCardProps) {
       </CardHeader>
 
       <CardContent className='space-y-4'>
-        <p className='text-sage-700 text-sm leading-relaxed line-clamp-3'>
+        <p className='text-sage-700 dark:text-slate-300 text-sm leading-relaxed line-clamp-3'>
           {project.description}
         </p>
 
@@ -79,7 +79,7 @@ export default function ProjectCard({ project, index }: ProjectCardProps) {
               <Badge
                 key={techIndex}
                 variant='secondary'
-                className='text-xs bg-emerald-100 text-emerald-700 hover:bg-emerald-200 transition-colors'
+                className='text-xs bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400 hover:bg-emerald-200 dark:hover:bg-emerald-900/50 transition-colors'
               >
                 {tech}
               </Badge>
@@ -92,7 +92,7 @@ export default function ProjectCard({ project, index }: ProjectCardProps) {
                 href={project.githubUrl}
                 target='_blank'
                 rel='noopener noreferrer'
-                className='inline-flex items-center gap-2 text-sage-600 hover:text-emerald-600 transition-colors text-sm font-medium'
+                className='inline-flex items-center gap-2 text-sage-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors text-sm font-medium'
                 aria-label={`View ${project.title} on GitHub`}
               >
                 <Github className='h-4 w-4' />
@@ -105,7 +105,7 @@ export default function ProjectCard({ project, index }: ProjectCardProps) {
                 href={project.projectUrl}
                 target='_blank'
                 rel='noopener noreferrer'
-                className='inline-flex items-center gap-2 text-sage-600 hover:text-emerald-600 transition-colors text-sm font-medium'
+                className='inline-flex items-center gap-2 text-sage-600 dark:text-slate-400 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors text-sm font-medium'
                 aria-label={`Visit ${project.title} live site`}
               >
                 <ExternalLink className='h-4 w-4' />

--- a/components/skills.tsx
+++ b/components/skills.tsx
@@ -51,13 +51,13 @@ export default function Skills() {
   ];
 
   return (
-    <section id='skills' className='py-20 bg-white'>
+    <section id='skills' className='py-20 bg-white dark:bg-background'>
       <div className='container mx-auto px-4 sm:px-6 lg:px-8'>
         <div className='text-center mb-16'>
-          <h2 className='text-3xl sm:text-4xl font-bold mb-4 text-sage-900'>
+          <h2 className='text-3xl sm:text-4xl font-bold mb-4 text-sage-900 dark:text-slate-100'>
             Skills & Expertise
           </h2>
-          <p className='text-lg text-sage-700 max-w-2xl mx-auto'>
+          <p className='text-lg text-sage-700 dark:text-slate-300 max-w-2xl mx-auto'>
             A comprehensive toolkit of technologies and skills developed through
             years of hands-on experience and continuous learning.
           </p>
@@ -65,9 +65,12 @@ export default function Skills() {
 
         <div className='grid md:grid-cols-2 lg:grid-cols-3 gap-6'>
           {skillCategories.map((category, index) => (
-            <Card key={index} className='h-full card-elegant hover-lift'>
+            <Card
+              key={index}
+              className='h-full card-elegant hover-lift glow-emerald'
+            >
               <CardHeader>
-                <CardTitle className='text-lg text-emerald-800'>
+                <CardTitle className='text-lg text-emerald-800 dark:text-emerald-400'>
                   {category.title}
                 </CardTitle>
               </CardHeader>
@@ -77,7 +80,7 @@ export default function Skills() {
                     <Badge
                       key={skillIndex}
                       variant='secondary'
-                      className='text-xs bg-emerald-100 text-emerald-700 hover:bg-emerald-200 transition-colors'
+                      className='text-xs bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400 hover:bg-emerald-200 dark:hover:bg-emerald-900/50 transition-colors'
                     >
                       {skill}
                     </Badge>

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -22,8 +22,8 @@ type ThemeProviderState = {
 };
 
 const initialState: ThemeProviderState = {
-  theme: 'system',
-  resolvedTheme: 'light',
+  theme: 'dark',
+  resolvedTheme: 'dark',
   setTheme: () => null,
   toggleTheme: () => null,
   systemTheme: 'light',
@@ -33,7 +33,7 @@ const ThemeProviderContext = createContext<ThemeProviderState>(initialState);
 
 export function ThemeProvider({
   children,
-  defaultTheme = 'system',
+  defaultTheme = 'dark',
   storageKey = 'geovanny-portfolio-theme',
   disableTransitionOnChange = false,
   ...props

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     './pages/**/*.{ts,tsx}',
     './components/**/*.{ts,tsx}',


### PR DESCRIPTION
## Summary

- Replaces the light emerald/sage palette with a near-black (`#0a0f0d`) dark-first design
- Adds `.dark` CSS variable block in `globals.css` with new dark palette tokens (background, card surface, muted, border, primary accent)
- Sets `defaultTheme = 'dark'` in `ThemeProvider` and adds `class="dark"` to `<html>` to prevent flash on load
- Introduces three new CSS utilities: `.gradient-text` (emerald→cyan), `.glass` (backdrop-blur card), `.glow-emerald` (hover neon glow)
- Updates all 15 section/card/page components with `dark:` Tailwind variants for text, backgrounds, badges, and borders
- Frosted glass navigation bar on scroll (`bg-black/70 backdrop-blur-xl`)
- Light mode fully preserved and togglable via the existing theme toggle

## Test plan

- [ ] Visual check: home page loads in dark mode by default
- [ ] Visual check: scroll through all sections — hero, about, skills, experience, education, awards, contact, footer
- [ ] Visual check: `/blog` and `/projects` pages render correctly in dark mode
- [ ] Toggle to light mode via the theme switcher — all sections render correctly
- [ ] `yarn type-check` passes
- [ ] `yarn lint` passes (0 errors)
- [ ] `yarn test` — all 112 tests pass
- [ ] `yarn build` — clean static export to `docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)