### PR TITLE
feat(health): add static /health endpoint

### DIFF
--- a/__tests__/app/health/route.test.ts
+++ b/__tests__/app/health/route.test.ts
@@ -1,0 +1,24 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/health/route';
+
+describe('GET /health', () => {
+  it('returns 200 with status ok', async () => {
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe('ok');
+  });
+
+  it('includes a built_at ISO timestamp', async () => {
+    const response = await GET();
+    const body = await response.json();
+    expect(body.built_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it('returns JSON content-type', async () => {
+    const response = await GET();
+    expect(response.headers.get('content-type')).toContain('application/json');
+  });
+});

--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -1,0 +1,8 @@
+export const dynamic = 'force-static';
+
+export async function GET() {
+  return Response.json({
+    status: 'ok',
+    built_at: new Date().toISOString(),
+  });
+}

--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -1,8 +1,10 @@
 export const dynamic = 'force-static';
 
+const BUILT_AT = new Date().toISOString();
+
 export async function GET() {
   return Response.json({
     status: 'ok',
-    built_at: new Date().toISOString(),
+    built_at: BUILT_AT,
   });
 }

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -29,36 +29,38 @@ jest.mock('next/image', () => ({
   },
 }));
 
-// Mock window.matchMedia
-Object.defineProperty(window, 'matchMedia', {
-  writable: true,
-  value: jest.fn().mockImplementation(query => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: jest.fn(), // deprecated
-    removeListener: jest.fn(), // deprecated
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  })),
-});
+if (typeof window !== 'undefined') {
+  // Mock window.matchMedia
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(), // deprecated
+      removeListener: jest.fn(), // deprecated
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
 
-// Mock IntersectionObserver
-global.IntersectionObserver = class IntersectionObserver {
-  constructor() {}
-  disconnect() {}
-  observe() {}
-  unobserve() {}
-};
+  // Mock IntersectionObserver
+  global.IntersectionObserver = class IntersectionObserver {
+    constructor() {}
+    disconnect() {}
+    observe() {}
+    unobserve() {}
+  };
 
-// Mock ResizeObserver
-global.ResizeObserver = class ResizeObserver {
-  constructor() {}
-  disconnect() {}
-  observe() {}
-  unobserve() {}
-};
+  // Mock ResizeObserver
+  global.ResizeObserver = class ResizeObserver {
+    constructor() {}
+    disconnect() {}
+    observe() {}
+    unobserve() {}
+  };
+}
 
 // Suppress console warnings during tests
 const originalError = console.error;


### PR DESCRIPTION
## Summary

- Adds `app/health/route.ts` — a static route handler at `/health` returning `{"status":"ok","built_at":"<ISO timestamp>"}` baked at build time
- Adds `__tests__/app/health/route.test.ts` — 3 tests covering HTTP 200, `status: ok` body, and JSON content-type (runs in `node` Jest environment via docblock)
- Guards browser-only mocks in `jest.setup.js` with `typeof window !== 'undefined'` so they don't crash when tests use the `node` environment

## Test plan

- [ ] `yarn test __tests__/app/health/route.test.ts` — all 3 tests pass
- [ ] `yarn test` — full suite (115 tests) still passes
- [ ] After deploy, `curl https://geovannycordero.com/health` returns `{"status":"ok","built_at":"..."}` with HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)